### PR TITLE
Fix dependencies problem #8 and clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,6 @@ exclude = ["examples/**", "axmldecoder-printer/**"]
 
 [dependencies]
 byteorder = "1.4.3"
-deku = "~0.13"
-indexmap = "1.7.0"
-thiserror = "1.0.30"
+deku = "~0.15"
+indexmap = "1.9.2"
+thiserror = "1.0.37"

--- a/axmldecoder-printer/Cargo.toml
+++ b/axmldecoder-printer/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.40"
+anyhow = "1.0.66"
 axmldecoder = { path = "../" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,11 @@ pub enum ParseError {
     Utf16StringParseError(std::string::FromUtf16Error),
 }
 
-///Parses an Android binary XML and returns a [XmlDocument] object.
+///Parses an Android binary XML and returns a [`XmlDocument`] object.
 ///
+/// # Errors
+///
+/// Will return `ParseError` if `input` cannot be parsed
 ///```rust
 ///use axmldecoder::parse;
 ///# use axmldecoder::ParseError;
@@ -76,7 +79,7 @@ mod tests {
             let mut f = File::open(entry.path()).unwrap();
             let mut buf = Vec::new();
             f.read_to_end(&mut buf).unwrap();
-            parse(&buf).expect(&format!("{} failed to parse", entry.path().display()));
+            parse(&buf).unwrap_or_else(|_| panic!("{} failed to parse", entry.path().display()));
         }
     }
 }

--- a/src/stringpool.rs
+++ b/src/stringpool.rs
@@ -26,7 +26,7 @@ pub(crate) struct StringPool {
     pub(crate) strings: Vec<Rc<String>>,
 }
 
-type DekuRest = BitSlice<Msb0, u8>;
+type DekuRest = BitSlice<u8, Msb0>;
 impl StringPool {
     fn read_strings<'a>(
         header: &StringPoolHeader,

--- a/src/stringpool.rs
+++ b/src/stringpool.rs
@@ -22,7 +22,7 @@ pub(crate) struct StringPoolHeader {
 #[derive(Debug, DekuRead)]
 pub(crate) struct StringPool {
     pub(crate) header: StringPoolHeader,
-    #[deku(reader = "StringPool::read_strings(&*header, deku::rest)")]
+    #[deku(reader = "StringPool::read_strings(header, deku::rest)")]
     pub(crate) strings: Vec<Rc<String>>,
 }
 
@@ -32,11 +32,12 @@ impl StringPool {
         header: &StringPoolHeader,
         mut rest: &'a DekuRest,
     ) -> Result<(&'a DekuRest, Vec<Rc<String>>), DekuError> {
+        const STRINGPOOL_HEADER_SIZE: usize = std::mem::size_of::<StringPoolHeader>();
+
         assert_eq!(header.style_count, 0);
 
         let flag_is_utf8 = (header.flags & (1 << 8)) != 0;
 
-        const STRINGPOOL_HEADER_SIZE: usize = std::mem::size_of::<StringPoolHeader>();
         let s = usize::try_from(header.chunk_header.size).unwrap() - STRINGPOOL_HEADER_SIZE;
 
         let mut string_pool_data = vec![0; s];


### PR DESCRIPTION
implements #8 and improves code style by removing some clippy warnings

I tested this with axmldecoder-printer in some of the xmls in examples, however we might want to consider adding real automated tests and CI